### PR TITLE
Use existed 9Patch pngs in device directory

### DIFF
--- a/fix_9patch_png.sh
+++ b/fix_9patch_png.sh
@@ -45,6 +45,10 @@ for file in `find $TMP_ORIGINAL_DIR -name *.9.png`; do
 	targetfile=`echo $file | sed -e "s/-original/-target/"`
 	cp $file $targetfile
 done
+for file in `find $1 -name *.9.png`; do
+	targetfile=$3/`echo $file | sed -e "s/$1/$1-target/"`
+	cp $file $targetfile
+done
 cd $TMP_TARGET_DIR
 #only store all files, not compress files
 #as raw resource can't be compressed.

--- a/fix_9patch_png.sh
+++ b/fix_9patch_png.sh
@@ -43,11 +43,16 @@ unzip $TMP_ORIGINAL_FILE -d $TMP_ORIGINAL_DIR
 unzip $TMP_TARGET_FILE -d $TMP_TARGET_DIR
 for file in `find $TMP_ORIGINAL_DIR -name *.9.png`; do
 	targetfile=`echo $file | sed -e "s/-original/-target/"`
-	cp $file $targetfile
-done
-for file in `find $1 -name *.9.png`; do
-	targetfile=$3/`echo $file | sed -e "s/$1/$1-target/"`
-	cp $file $targetfile
+	flag=0
+	for file2 in `find $1 -name *.9.png`; do
+		if [ $file = $file2 ]; then
+		flag=1
+		break
+		fi    
+	done
+	if [ -z $flag ]; then
+		cp $file $targetfile
+	fi    
 done
 cd $TMP_TARGET_DIR
 #only store all files, not compress files


### PR DESCRIPTION
如果机型目录下存在经过修改的9Patch png文件，优先使用机型目录下的文件来覆盖，否则在机型目录下对MIUI相应APP里的9Patch png文件作的任何修改将无效，那就无法根据各机型的屏幕特性来调整MIUI APP的UI了
